### PR TITLE
Not all LCS will have deployed their MS hosted environments

### DIFF
--- a/2LCS/Forms/MainForm.cs
+++ b/2LCS/Forms/MainForm.cs
@@ -180,16 +180,20 @@ namespace LCS.Forms
             if (reloadFromLcs)
             {
                 _saasInstancesList = _httpClientHelper.GetSaasInstances();
-                _saasInstancesSource.DataSource = _saasInstancesList;
-                if(Instances.Exists(x => x.LcsProjectId == _selectedProject.Id))
+
+                if (_saasInstancesList != null)
                 {
-                    Instances.Where(x => x.LcsProjectId == _selectedProject.Id)
-                        .Select(x => { x.SaasInstances = _saasInstancesList; return x;} )
-                            .ToList();
+                    _saasInstancesSource.DataSource = _saasInstancesList;
+                    if (Instances.Exists(x => x.LcsProjectId == _selectedProject.Id))
+                    {
+                        Instances.Where(x => x.LcsProjectId == _selectedProject.Id)
+                            .Select(x => { x.SaasInstances = _saasInstancesList; return x; })
+                                .ToList();
+                    }
+
+                    Properties.Settings.Default.instances = JsonConvert.SerializeObject(Instances, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                    Properties.Settings.Default.Save();
                 }
-                
-                Properties.Settings.Default.instances = JsonConvert.SerializeObject(Instances, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
-                Properties.Settings.Default.Save();
             }
             else
             {
@@ -209,16 +213,19 @@ namespace LCS.Forms
             if (reloadFromLcs)
             {
                 _cheInstancesList = _httpClientHelper.GetCheInstances();
-                _cheInstancesSource.DataSource = _cheInstancesList;
-                if(Instances.Exists(x => x.LcsProjectId == _selectedProject.Id))
+                if (_cheInstancesList != null)
                 {
-                    Instances.Where(x => x.LcsProjectId == _selectedProject.Id)
-                        .Select(x => { x.CheInstances = _cheInstancesList; return x;} )
-                            .ToList();
-                }
-                
-                Properties.Settings.Default.instances = JsonConvert.SerializeObject(Instances, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
-                Properties.Settings.Default.Save();
+                    _cheInstancesSource.DataSource = _cheInstancesList;
+                    if (Instances.Exists(x => x.LcsProjectId == _selectedProject.Id))
+                    {
+                        Instances.Where(x => x.LcsProjectId == _selectedProject.Id)
+                            .Select(x => { x.CheInstances = _cheInstancesList; return x; })
+                                .ToList();
+                    }
+
+                    Properties.Settings.Default.instances = JsonConvert.SerializeObject(Instances, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+                    Properties.Settings.Default.Save();
+                }                
             }
             else
             {

--- a/2LCS/HttpClientHelper.cs
+++ b/2LCS/HttpClientHelper.cs
@@ -104,11 +104,21 @@ namespace LCS
 
             var responseBody = result.Content.ReadAsStringAsync().Result;
             var response = JsonConvert.DeserializeObject<Response>(responseBody);
+
+            //Not all LCS will have deployed their MS hosted environments. JsonConvert.DeserializeObject doesn't tolerate nulls be default.
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                MissingMemberHandling = MissingMemberHandling.Ignore
+            };
+
             if (response.Success)
             {
                 if (response.Data != null)
                 {
-                    var instances = JsonConvert.DeserializeObject<List<SAASInstance>>(response.Data.ToString());
+                    //Not all LCS will have deployed their MS hosted environments. JsonConvert.DeserializeObject doesn't tolerate nulls be default.
+                    var instances = JsonConvert.DeserializeObject<List<SAASInstance>>(response.Data.ToString(), settings);
+
                     if (instances != null)
                     {
                         List<CloudHostedInstance> list = new List<CloudHostedInstance>();
@@ -119,7 +129,7 @@ namespace LCS
                                 if (instance.IsDeployed == true)
                                 {
                                     var details = GetSaasDeploymentDetail(instance.EnvironmentId);
-                                    if(details != null)
+                                    if (details != null)
                                     {
                                         list.Add(details);
                                     }

--- a/2LCS/HttpClientHelper.cs
+++ b/2LCS/HttpClientHelper.cs
@@ -81,20 +81,26 @@ namespace LCS
         internal List<CloudHostedInstance> GetCheInstances()
         {
             var result = _httpClient.GetAsync($"{LcsUrl}/DeploymentPortal/GetDeployementDetails/{LcsProjectId}?_={DateTimeOffset.Now.ToUnixTimeSeconds()}").Result;
-            result.EnsureSuccessStatusCode();
 
-            var responseBody = result.Content.ReadAsStringAsync().Result;
-            responseBody = responseBody.TrimStart('(');
-            responseBody = responseBody.TrimEnd(')');
-
-            var cloudHostedInstancesUnsorted = JsonConvert.DeserializeObject<Dictionary<string, CloudHostedInstance>>(responseBody);
-
-            List<CloudHostedInstance> list = new List<CloudHostedInstance>();
-            if(cloudHostedInstancesUnsorted != null)
+            if (result.IsSuccessStatusCode)
             {
-                list.AddRange( cloudHostedInstancesUnsorted.Values.OrderBy(x => x.InstanceId));
+                result.EnsureSuccessStatusCode();
+
+                var responseBody = result.Content.ReadAsStringAsync().Result;
+                responseBody = responseBody.TrimStart('(');
+                responseBody = responseBody.TrimEnd(')');
+
+                var cloudHostedInstancesUnsorted = JsonConvert.DeserializeObject<Dictionary<string, CloudHostedInstance>>(responseBody);
+
+                List<CloudHostedInstance> list = new List<CloudHostedInstance>();
+                if (cloudHostedInstancesUnsorted != null)
+                {
+                    list.AddRange(cloudHostedInstancesUnsorted.Values.OrderBy(x => x.InstanceId));
+                }
+                return list;
             }
-            return list;
+
+            return null;
         }
 
         internal List<CloudHostedInstance> GetSaasInstances()


### PR DESCRIPTION
The JsonConvert.DeserializeObject method doesn't allow nulls by default. The issues arises working against projects where the SaaS / Hosted Environments hasn't been deployed.