### PR TITLE
Automatically close original ChooseProject instance when refreshing cookie

### DIFF
--- a/2LCS/Forms/MainForm.cs
+++ b/2LCS/Forms/MainForm.cs
@@ -1417,7 +1417,7 @@ namespace LCS.Forms
             logoutToolStripMenuItem.Enabled = true;
             loginToLcsMenuItem.Enabled = false;
             ChangeProjectMenuItem_Click(null, null);
-        }        
+        }
 
         private void LogonToApplicationToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/2LCS/Program.cs
+++ b/2LCS/Program.cs
@@ -14,10 +14,12 @@ namespace LCS
             {
                 case "System.Net.Http" when e.Exception.Message == $"Response status code does not indicate success: 498 ().":
                 case "mscorlib" when e.Exception.InnerException.Message == $"Response status code does not indicate success: 498 ().":
-                    MessageBox.Show("Please login to LCS again. Your cookie is probably invalid or expired.");
+                    MessageBox.Show("Please login to LCS again. Your cookie is probably invalid or expired.");                                        
                     var mainForm = GetMainForm();
                     mainForm.Cursor = Cursors.Default;
                     mainForm.SetLoginButtonEnabled();
+                    // Close first instance of ChooseProject form (if open) before calling LoginToLCSMenuItem_Click which opens another ChooseProject instance
+                    CloseChooseProject();
                     mainForm.LoginToLCSMenuItem_Click(null, null);
                     break;
 
@@ -34,6 +36,17 @@ namespace LCS
             return null;
         }
 
+        private static void CloseChooseProject()
+        {
+            foreach (Form form in Application.OpenForms)
+                if (form is ChooseProject)
+                {
+                    var chooseProject = (ChooseProject)form;
+                    chooseProject.Close();                    
+                }
+
+        }
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
@@ -41,12 +54,7 @@ namespace LCS
         private static void Main()
         {
             Application.ThreadException += new ThreadExceptionEventHandler(Application_ThreadException);
-
-            if (Debugger.IsAttached)
-            {
-                Properties.Settings.Default.Reset();
-            }
-
+            
             // Copy user settings from previous application version if necessary
             if (Properties.Settings.Default.update)
             {


### PR DESCRIPTION
When the cookie is refreshed a new instance of the ChooseProject form is opened but the original is still open too:

![2020-03-26 11_09_50](https://user-images.githubusercontent.com/3646112/77636472-77703600-6f54-11ea-93f4-93529a24df95.png)

If the new ChooseProject form is closed and try to change the project with the original instance I think the cookie value is still the old one and this causes 2LCS to try to refresh the cookie again, and open a new instance of the ChooseProject form.

Now the original ChooseForm instance will be closed if the new one is too, avoiding the issue.

Also a "if (Debugger.IsAttached)" has been removed from a previous PR.