### PR TITLE
Added "Always log as admin" parameter for CHE RDPs

### DIFF
--- a/2LCS/App.config
+++ b/2LCS/App.config
@@ -43,6 +43,9 @@
             <setting name="keepCache" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="alwaysLogAsAdmin" serializeAs="String">
+                <value>False</value>
+            </setting>
         </LCS.Properties.Settings>
     </userSettings>
   <runtime>

--- a/2LCS/Forms/MainForm.cs
+++ b/2LCS/Forms/MainForm.cs
@@ -83,52 +83,59 @@ namespace LCS.Forms
 
         public static RDPConnectionDetails ChooseRdpLogonUser(List<RDPConnectionDetails> rdpList)
         {
-            Form form = new Form();
-            Button button_OK = new Button() { Text = "OK", Location = new Point(60, 30) };
-            Button button_Cancel = new Button() { Text = "Cancel", Location = new Point(140, 30) };
-            button_OK.DialogResult = DialogResult.OK;
-            button_Cancel.DialogResult = DialogResult.Cancel;
-            FlowLayoutPanel panel = new FlowLayoutPanel
+            if (Properties.Settings.Default.alwaysLogAsAdmin)
             {
-                Dock = DockStyle.Fill
-            };
-
-            form.Text = "Choose user";
-            form.ClientSize = new Size(280, 60);
-            form.FormBorderStyle = FormBorderStyle.FixedDialog;
-            form.StartPosition = FormStartPosition.CenterScreen;
-            form.AcceptButton = button_OK;
-            form.CancelButton = button_Cancel;
-            form.MinimizeBox = false;
-            form.MaximizeBox = false;
-            form.ControlBox = false;
-
-            form.Controls.AddRange(new Control[] { button_OK, button_Cancel });
-            var i = 1;
-            foreach (var rdpEntry in rdpList.OrderBy(x => x.Username))
-            {
-                if (i == 1)
-                {
-                    panel.Controls.Add(new RadioButton() { Text = rdpEntry.Username, Checked = true });
-                }
-                else
-                {
-                    panel.Controls.Add(new RadioButton() { Text = rdpEntry.Username });
-                }
-                i++;
+                return rdpList.FirstOrDefault(x => x.Username.Contains("Admin"));
             }
-            form.Controls.Add(panel);
+            else
+            {
+                Form form = new Form();
+                Button button_OK = new Button() { Text = "OK", Location = new Point(60, 30) };
+                Button button_Cancel = new Button() { Text = "Cancel", Location = new Point(140, 30) };
+                button_OK.DialogResult = DialogResult.OK;
+                button_Cancel.DialogResult = DialogResult.Cancel;
+                FlowLayoutPanel panel = new FlowLayoutPanel
+                {
+                    Dock = DockStyle.Fill
+                };
 
-            DialogResult dialogResult = form.ShowDialog();
+                form.Text = "Choose user";
+                form.ClientSize = new Size(280, 60);
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterScreen;
+                form.AcceptButton = button_OK;
+                form.CancelButton = button_Cancel;
+                form.MinimizeBox = false;
+                form.MaximizeBox = false;
+                form.ControlBox = false;
 
-            if (dialogResult == DialogResult.Cancel)
-                return null;
+                form.Controls.AddRange(new Control[] { button_OK, button_Cancel });
+                var i = 1;
+                foreach (var rdpEntry in rdpList.OrderBy(x => x.Username))
+                {
+                    if (i == 1)
+                    {
+                        panel.Controls.Add(new RadioButton() { Text = rdpEntry.Username, Checked = true });
+                    }
+                    else
+                    {
+                        panel.Controls.Add(new RadioButton() { Text = rdpEntry.Username });
+                    }
+                    i++;
+                }
+                form.Controls.Add(panel);
 
-            RadioButton rbSelected = panel.Controls
-                         .OfType<RadioButton>()
-                         .FirstOrDefault(r => r.Checked);
+                DialogResult dialogResult = form.ShowDialog();
 
-            return rdpList.FirstOrDefault(x => x.Username.Equals(rbSelected.Text));
+                if (dialogResult == DialogResult.Cancel)
+                    return null;
+
+                RadioButton rbSelected = panel.Controls
+                             .OfType<RadioButton>()
+                             .FirstOrDefault(r => r.Checked);
+
+                return rdpList.FirstOrDefault(x => x.Username.Equals(rbSelected.Text));
+            }
         }
 
         public static bool IsOverlapped(IWin32Window window)

--- a/2LCS/Forms/Parameters.Designer.cs
+++ b/2LCS/Forms/Parameters.Designer.cs
@@ -39,18 +39,20 @@
             this.ClearCacheButton = new System.Windows.Forms.Button();
             this.StoreCacheCheckBox = new System.Windows.Forms.CheckBox();
             this.CachingEnabledCheckbox = new System.Windows.Forms.CheckBox();
+            this.groupCHE = new System.Windows.Forms.GroupBox();
+            this.alwaysLogAsAdmin = new System.Windows.Forms.CheckBox();
             this.groupBoxExportConfig.SuspendLayout();
             this.groupBoxUIConfig.SuspendLayout();
             this.groupBoxCaching.SuspendLayout();
+            this.groupCHE.SuspendLayout();
             this.SuspendLayout();
             // 
             // AutoRefreshCheckBox
             // 
             this.AutoRefreshCheckBox.AutoSize = true;
-            this.AutoRefreshCheckBox.Location = new System.Drawing.Point(11, 30);
-            this.AutoRefreshCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.AutoRefreshCheckBox.Location = new System.Drawing.Point(8, 20);
             this.AutoRefreshCheckBox.Name = "AutoRefreshCheckBox";
-            this.AutoRefreshCheckBox.Size = new System.Drawing.Size(474, 29);
+            this.AutoRefreshCheckBox.Size = new System.Drawing.Size(351, 21);
             this.AutoRefreshCheckBox.TabIndex = 0;
             this.AutoRefreshCheckBox.Text = "Auto-refresh list of instances after switching project";
             this.AutoRefreshCheckBox.UseVisualStyleBackColor = true;
@@ -58,10 +60,9 @@
             // closeButton
             // 
             this.closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.closeButton.Location = new System.Drawing.Point(429, 402);
-            this.closeButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.closeButton.Location = new System.Drawing.Point(312, 331);
             this.closeButton.Name = "closeButton";
-            this.closeButton.Size = new System.Drawing.Size(224, 39);
+            this.closeButton.Size = new System.Drawing.Size(163, 26);
             this.closeButton.TabIndex = 4;
             this.closeButton.Text = "Close";
             this.closeButton.UseVisualStyleBackColor = true;
@@ -71,41 +72,35 @@
             // 
             this.groupBoxExportConfig.Controls.Add(this.labelOrgNameExcl);
             this.groupBoxExportConfig.Controls.Add(this.textBoxProjectExcl);
-            this.groupBoxExportConfig.Location = new System.Drawing.Point(17, 268);
-            this.groupBoxExportConfig.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBoxExportConfig.Location = new System.Drawing.Point(12, 179);
             this.groupBoxExportConfig.Name = "groupBoxExportConfig";
-            this.groupBoxExportConfig.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBoxExportConfig.Size = new System.Drawing.Size(636, 109);
+            this.groupBoxExportConfig.Size = new System.Drawing.Size(463, 73);
             this.groupBoxExportConfig.TabIndex = 5;
             this.groupBoxExportConfig.TabStop = false;
             this.groupBoxExportConfig.Text = "Export instances/updates";
             // 
             // labelOrgNameExcl
             // 
-            this.labelOrgNameExcl.Location = new System.Drawing.Point(6, 37);
-            this.labelOrgNameExcl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelOrgNameExcl.Location = new System.Drawing.Point(4, 25);
             this.labelOrgNameExcl.Name = "labelOrgNameExcl";
-            this.labelOrgNameExcl.Size = new System.Drawing.Size(332, 52);
+            this.labelOrgNameExcl.Size = new System.Drawing.Size(241, 35);
             this.labelOrgNameExcl.TabIndex = 1;
             this.labelOrgNameExcl.Text = "Exclude projects for all organizations containing the following string\r\n\r\n";
             // 
             // textBoxProjectExcl
             // 
-            this.textBoxProjectExcl.Location = new System.Drawing.Point(345, 59);
-            this.textBoxProjectExcl.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.textBoxProjectExcl.Location = new System.Drawing.Point(251, 39);
             this.textBoxProjectExcl.Name = "textBoxProjectExcl";
-            this.textBoxProjectExcl.Size = new System.Drawing.Size(286, 29);
+            this.textBoxProjectExcl.Size = new System.Drawing.Size(209, 22);
             this.textBoxProjectExcl.TabIndex = 0;
             // 
             // groupBoxUIConfig
             // 
             this.groupBoxUIConfig.Controls.Add(this.minimizeToNotificationArea);
             this.groupBoxUIConfig.Controls.Add(this.AutoRefreshCheckBox);
-            this.groupBoxUIConfig.Location = new System.Drawing.Point(17, 13);
-            this.groupBoxUIConfig.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBoxUIConfig.Location = new System.Drawing.Point(12, 9);
             this.groupBoxUIConfig.Name = "groupBoxUIConfig";
-            this.groupBoxUIConfig.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBoxUIConfig.Size = new System.Drawing.Size(636, 121);
+            this.groupBoxUIConfig.Size = new System.Drawing.Size(463, 81);
             this.groupBoxUIConfig.TabIndex = 6;
             this.groupBoxUIConfig.TabStop = false;
             this.groupBoxUIConfig.Text = "UI";
@@ -113,10 +108,10 @@
             // minimizeToNotificationArea
             // 
             this.minimizeToNotificationArea.AutoSize = true;
-            this.minimizeToNotificationArea.Location = new System.Drawing.Point(10, 69);
-            this.minimizeToNotificationArea.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.minimizeToNotificationArea.Location = new System.Drawing.Point(7, 46);
+            this.minimizeToNotificationArea.Margin = new System.Windows.Forms.Padding(4);
             this.minimizeToNotificationArea.Name = "minimizeToNotificationArea";
-            this.minimizeToNotificationArea.Size = new System.Drawing.Size(459, 29);
+            this.minimizeToNotificationArea.Size = new System.Drawing.Size(335, 21);
             this.minimizeToNotificationArea.TabIndex = 2;
             this.minimizeToNotificationArea.Text = "Closing the window minimizes to notification area";
             this.minimizeToNotificationArea.UseVisualStyleBackColor = true;
@@ -126,21 +121,19 @@
             this.groupBoxCaching.Controls.Add(this.ClearCacheButton);
             this.groupBoxCaching.Controls.Add(this.StoreCacheCheckBox);
             this.groupBoxCaching.Controls.Add(this.CachingEnabledCheckbox);
-            this.groupBoxCaching.Location = new System.Drawing.Point(17, 142);
-            this.groupBoxCaching.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBoxCaching.Location = new System.Drawing.Point(12, 95);
             this.groupBoxCaching.Name = "groupBoxCaching";
-            this.groupBoxCaching.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.groupBoxCaching.Size = new System.Drawing.Size(636, 118);
+            this.groupBoxCaching.Size = new System.Drawing.Size(463, 79);
             this.groupBoxCaching.TabIndex = 7;
             this.groupBoxCaching.TabStop = false;
             this.groupBoxCaching.Text = "Caching";
             // 
             // ClearCacheButton
             // 
-            this.ClearCacheButton.Location = new System.Drawing.Point(432, 60);
-            this.ClearCacheButton.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.ClearCacheButton.Location = new System.Drawing.Point(314, 40);
+            this.ClearCacheButton.Margin = new System.Windows.Forms.Padding(4);
             this.ClearCacheButton.Name = "ClearCacheButton";
-            this.ClearCacheButton.Size = new System.Drawing.Size(194, 42);
+            this.ClearCacheButton.Size = new System.Drawing.Size(141, 28);
             this.ClearCacheButton.TabIndex = 2;
             this.ClearCacheButton.Text = "Clear cache";
             this.ClearCacheButton.UseVisualStyleBackColor = true;
@@ -149,10 +142,9 @@
             // StoreCacheCheckBox
             // 
             this.StoreCacheCheckBox.AutoSize = true;
-            this.StoreCacheCheckBox.Location = new System.Drawing.Point(7, 68);
-            this.StoreCacheCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.StoreCacheCheckBox.Location = new System.Drawing.Point(5, 45);
             this.StoreCacheCheckBox.Name = "StoreCacheCheckBox";
-            this.StoreCacheCheckBox.Size = new System.Drawing.Size(375, 29);
+            this.StoreCacheCheckBox.Size = new System.Drawing.Size(276, 21);
             this.StoreCacheCheckBox.TabIndex = 1;
             this.StoreCacheCheckBox.Text = "Save cache on exit and load on startup";
             this.StoreCacheCheckBox.UseVisualStyleBackColor = true;
@@ -160,26 +152,45 @@
             // CachingEnabledCheckbox
             // 
             this.CachingEnabledCheckbox.AutoSize = true;
-            this.CachingEnabledCheckbox.Location = new System.Drawing.Point(7, 30);
-            this.CachingEnabledCheckbox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.CachingEnabledCheckbox.Location = new System.Drawing.Point(5, 20);
             this.CachingEnabledCheckbox.Name = "CachingEnabledCheckbox";
-            this.CachingEnabledCheckbox.Size = new System.Drawing.Size(199, 29);
+            this.CachingEnabledCheckbox.Size = new System.Drawing.Size(146, 21);
             this.CachingEnabledCheckbox.TabIndex = 0;
             this.CachingEnabledCheckbox.Text = "Enabled (memory)";
             this.CachingEnabledCheckbox.UseVisualStyleBackColor = true;
             this.CachingEnabledCheckbox.CheckedChanged += new System.EventHandler(this.CachingEnabledCheckbox_CheckedChanged);
             // 
+            // groupCHE
+            // 
+            this.groupCHE.Controls.Add(this.alwaysLogAsAdmin);
+            this.groupCHE.Location = new System.Drawing.Point(13, 259);
+            this.groupCHE.Margin = new System.Windows.Forms.Padding(4);
+            this.groupCHE.Name = "groupCHE";
+            this.groupCHE.Padding = new System.Windows.Forms.Padding(4);
+            this.groupCHE.Size = new System.Drawing.Size(462, 58);
+            this.groupCHE.TabIndex = 9;
+            this.groupCHE.TabStop = false;
+            this.groupCHE.Text = "Cloud-hosted environments";
+            // 
+            // alwaysLogAsAdmin
+            // 
+            this.alwaysLogAsAdmin.Location = new System.Drawing.Point(7, 22);
+            this.alwaysLogAsAdmin.Name = "alwaysLogAsAdmin";
+            this.alwaysLogAsAdmin.Size = new System.Drawing.Size(204, 24);
+            this.alwaysLogAsAdmin.TabIndex = 0;
+            this.alwaysLogAsAdmin.Text = "Always log as admin user";
+            // 
             // Parameters
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(714, 463);
+            this.ClientSize = new System.Drawing.Size(519, 369);
             this.Controls.Add(this.groupBoxUIConfig);
             this.Controls.Add(this.groupBoxCaching);
             this.Controls.Add(this.groupBoxExportConfig);
+            this.Controls.Add(this.groupCHE);
             this.Controls.Add(this.closeButton);
             this.Icon = global::LCS.Properties.Resources.favicon_blue;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "Parameters";
@@ -194,6 +205,7 @@
             this.groupBoxUIConfig.PerformLayout();
             this.groupBoxCaching.ResumeLayout(false);
             this.groupBoxCaching.PerformLayout();
+            this.groupCHE.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -216,5 +228,7 @@
         private System.Windows.Forms.CheckBox CachingEnabledCheckbox;
         private System.Windows.Forms.Button ClearCacheButton;
         private System.Windows.Forms.CheckBox minimizeToNotificationArea;
+        private System.Windows.Forms.GroupBox groupCHE;
+        private System.Windows.Forms.CheckBox alwaysLogAsAdmin;
     }
 }

--- a/2LCS/Forms/Parameters.cs
+++ b/2LCS/Forms/Parameters.cs
@@ -39,6 +39,7 @@ namespace LCS.Forms
             textBoxProjectExcl.Text = Properties.Settings.Default.projOrgExcl;
             CachingEnabledCheckbox.Checked = Properties.Settings.Default.cachingEnabled;
             StoreCacheCheckBox.Checked = Properties.Settings.Default.keepCache;
+            alwaysLogAsAdmin.Checked = Properties.Settings.Default.alwaysLogAsAdmin;
             SetStoreCacheEnabledDisabled();
         }
 
@@ -49,6 +50,7 @@ namespace LCS.Forms
             Properties.Settings.Default.projOrgExcl = textBoxProjectExcl.Text;
             Properties.Settings.Default.cachingEnabled = CachingEnabledCheckbox.Checked;
             Properties.Settings.Default.keepCache = StoreCacheCheckBox.Checked;
+            Properties.Settings.Default.alwaysLogAsAdmin = alwaysLogAsAdmin.Checked;
             Properties.Settings.Default.Save();
         }
 

--- a/2LCS/Properties/Settings.Designer.cs
+++ b/2LCS/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace LCS.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -152,6 +152,18 @@ namespace LCS.Properties {
             }
             set {
                 this["keepCache"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool alwaysLogAsAdmin {
+            get {
+                return ((bool)(this["alwaysLogAsAdmin"]));
+            }
+            set {
+                this["alwaysLogAsAdmin"] = value;
             }
         }
     }

--- a/2LCS/Properties/Settings.settings
+++ b/2LCS/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="keepCache" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="alwaysLogAsAdmin" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Added "Always log as admin" parameter for CHE and functionality. 

If the parameter is enabled the user selection for cloud-hosted environments will be bypassed and the admin user selected to open the RDP connection.