### PR TITLE
Enhance Login form with URL for faster logon and adjusted form size

### DIFF
--- a/2LCS/Forms/Login.Designer.cs
+++ b/2LCS/Forms/Login.Designer.cs
@@ -35,23 +35,23 @@
             // 
             this.webBrowser1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.webBrowser1.Location = new System.Drawing.Point(0, 0);
-            this.webBrowser1.MinimumSize = new System.Drawing.Size(20, 20);
+            this.webBrowser1.MinimumSize = new System.Drawing.Size(450, 410);
             this.webBrowser1.Name = "webBrowser1";
             this.webBrowser1.ScriptErrorsSuppressed = true;
-            this.webBrowser1.Size = new System.Drawing.Size(1550, 822);
+            this.webBrowser1.Size = new System.Drawing.Size(700, 650);
             this.webBrowser1.TabIndex = 0;
             this.webBrowser1.UserAgent = null;
             this.webBrowser1.Navigated += new System.Windows.Forms.WebBrowserNavigatedEventHandler(this.WebBrowser1_Navigated);
             // 
             // Login
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1550, 822);
+            this.ClientSize = new System.Drawing.Size(700, 650);
             this.Controls.Add(this.webBrowser1);
             this.Icon = global::LCS.Properties.Resources.favicon_blue;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(900, 600);
+            this.MinimumSize = new System.Drawing.Size(450, 410);
             this.Name = "Login";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;

--- a/2LCS/Forms/Login.cs
+++ b/2LCS/Forms/Login.cs
@@ -15,7 +15,7 @@ namespace LCS.Forms
         private void Login_Load(object sender, EventArgs e)
         {
             Cancelled = true;
-            webBrowser1.Navigate("https://lcs.dynamics.com");
+            webBrowser1.Navigate("https://lcs.dynamics.com/Logon/AdLogon");
         }
 
         private void WebBrowser1_Navigated(object sender, WebBrowserNavigatedEventArgs e)


### PR DESCRIPTION
- Change Login page URL to get rid of extra green Login button click - page with user name box will be loaded immediately
- Adjust MinimumSize for Login form to fit login form
- Adjust AutoScaleDimensions to 100%-scale value, more appropriate value

Default size login page
![image](https://user-images.githubusercontent.com/1720689/92595183-9f5a1880-f2ac-11ea-9744-4561daa0b905.png)

Minimum size login page
![image](https://user-images.githubusercontent.com/1720689/92595344-e3e5b400-f2ac-11ea-9626-37b4e5b6119c.png)
