### PR TITLE
TopologyVersion can now be a string

### DIFF
--- a/2LCS/JsonObjects.cs
+++ b/2LCS/JsonObjects.cs
@@ -473,7 +473,7 @@ namespace LCS.JsonObjects
         public object TopologyId { get; set; }
         public object TopologyName { get; set; }
         public object TopologyType { get; set; }
-        public int TopologyVersion { get; set; }
+        public object TopologyVersion { get; set; }
     }
 
     public class HostedInstance


### PR DESCRIPTION
Fixes #57 

Leaving as object following other variables