### PR TITLE
Changing object model to accomodate new property

### DIFF
--- a/2LCS/Forms/MainForm.cs
+++ b/2LCS/Forms/MainForm.cs
@@ -2275,7 +2275,7 @@ namespace LCS.Forms
 
             Cursor = Cursors.WaitCursor;
             var previousProject = _selectedProject;
-            var exportedUpdates = new List<Datum>();
+            var exportedUpdates = new List<UpcomingCalendarViewModels>();
 
             Projects = _httpClientHelper.GetAllProjects();
             Projects = ExcludeProjectsForOrganization(Projects); //remove all internal projects for export.
@@ -2287,8 +2287,8 @@ namespace LCS.Forms
                 _httpClientHelper.ChangeLcsProjectId(_project.Id.ToString());
                 SetLcsProjectText();
 
-                List<Datum> calendar = _httpClientHelper.GetUpcomingCalendars();
-                if (calendar != null || calendar.Count != 0)
+                List<UpcomingCalendarViewModels> calendar = _httpClientHelper.GetUpcomingCalendars();
+                if (calendar != null && calendar.Any())
                 {
                     foreach (var _updateRow in calendar)
                     {

--- a/2LCS/Forms/UpcomingUpdates.cs
+++ b/2LCS/Forms/UpcomingUpdates.cs
@@ -9,7 +9,7 @@ namespace LCS.Forms
 {
     public partial class UpcomingUpdates : Form
     {
-        public List<Datum> Calendar;
+        public List<UpcomingCalendarViewModels> Calendar;
         private readonly BindingSource _calendarSource = new BindingSource();
         private bool _sortAscending;
 

--- a/2LCS/HttpClientHelper.cs
+++ b/2LCS/HttpClientHelper.cs
@@ -771,7 +771,7 @@ namespace LCS
                 : response.Data == null ? null : JsonConvert.DeserializeObject<PlanData>(response.Data.ToString());
         }
 
-        internal List<Datum> GetUpcomingCalendars()
+        internal List<UpcomingCalendarViewModels> GetUpcomingCalendars()
         {
             try
             {
@@ -779,10 +779,10 @@ namespace LCS
                 result.EnsureSuccessStatusCode();
 
                 var responseBody = result.Content.ReadAsStringAsync().Result;
-                var response = JsonConvert.DeserializeObject<Response>(responseBody);
+                dynamic response = JsonConvert.DeserializeObject<Response>(responseBody);
                 return !response.Success
                     ? null
-                    : response.Data == null ? null : JsonConvert.DeserializeObject<List<Datum>>(response.Data.ToString());
+                    : response.Data == null ? null : JsonConvert.DeserializeObject<List<UpcomingCalendarViewModels>>(response.Data.UpcomingCalendarViewModels.ToString());
             }
             catch
             {

--- a/2LCS/JsonObjects.cs
+++ b/2LCS/JsonObjects.cs
@@ -550,7 +550,7 @@ namespace LCS.JsonObjects
         public List<Plan> Plans { get; set; }
     }
 
-    public class Datum
+    public class UpcomingCalendarViewModels
     {
         public string EnvironmentName { get; set; }
         public int StatusEnum { get; set; }
@@ -561,7 +561,7 @@ namespace LCS.JsonObjects
         public string Month { get; set; }
         public string Date { get; set; }
         public string Time { get; set; }
-        public int DownTime { get; set; }
+        public int DownTimeInMinutes { get; set; }
         public string EventName { get; set; }
         public string Status { get; set; }
         public bool IsModified { get; set; }


### PR DESCRIPTION
New property seen on when trying to export calendar updates - property DownTime was changed to DownTimeInMinutes. Data contains UpcomingCalendarViewModel array causing exception

```Json
{
	"Success": true,
	"Message": null,
	"MessageTitle": null,
	"Data": {
		"UpcomingCalendarViewModels": [
			{
				"EnvironmentName": "ENV",
				"StatusEnum": 5,
				"EventNameEnum": 0,
				"CalendarId": 999999,
				"UtcStartDateTime": "2021-07-10T08:00:00",
				"EnvironmentId": "999999-9999-999-9999-999999999999",
				"Month": "July",
				"Date": "2021-07-10",
				"Time": "04:00 AM",
				*"DownTimeInMinutes": 180,*
				"EventName": "Update Sandbox",
				"Status": "Paused",
				"IsModified": false,
				"WorkflowInstanceId": 99999
			}
		]
	}
}
```