### PR TITLE
Export user list to CSV (All projects or Current project) 

### DIFF
--- a/2LCS/App.config
+++ b/2LCS/App.config
@@ -31,6 +31,12 @@
             <setting name="projOrgExcl" serializeAs="String">
                 <value />
             </setting>
+			<setting name="RDPCredentialsEnabled" serializeAs="String">
+				<value />
+			</setting>
+			<setting name="LocalCredentialsEnabled" serializeAs="String">
+				<value />
+			</setting>
             <setting name="cachingEnabled" serializeAs="String">
                 <value>False</value>
             </setting>

--- a/2LCS/Forms/MainForm.Designer.cs
+++ b/2LCS/Forms/MainForm.Designer.cs
@@ -92,6 +92,9 @@
             this.customLinksToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportProjectDataToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportListOfUsersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.currentProjectUsersExportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.allProjectUsersExportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportListOfInstancesForAllProjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.allInstancesExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.allProjectsTSMExportAllInstances = new System.Windows.Forms.ToolStripMenuItem();
@@ -734,6 +737,7 @@
             // 
             this.exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportProjectDataToolStripMenuItem1,
+            this.exportListOfUsersToolStripMenuItem,
             this.exportListOfInstancesForAllProjectsToolStripMenuItem,
             this.exportUpdateScheduleForAllProjectsToolStripMenuItem,
             this.exportListOfEnvChangesToolStripMenuItem});
@@ -748,6 +752,29 @@
             this.exportProjectDataToolStripMenuItem1.Size = new System.Drawing.Size(357, 22);
             this.exportProjectDataToolStripMenuItem1.Text = "Export project data";
             this.exportProjectDataToolStripMenuItem1.Click += new System.EventHandler(this.ExportProjectDataToolStripMenuItem_Click);
+            // 
+            // exportListOfUsersToolStripMenuItem
+            // 
+            this.exportListOfUsersToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.allProjectUsersExportMenuItem,
+            this.currentProjectUsersExportMenuItem});
+            this.exportListOfUsersToolStripMenuItem.Name = "exportListOfUsersToolStripMenuItem";
+            this.exportListOfUsersToolStripMenuItem.Size = new System.Drawing.Size(357, 22);
+            this.exportListOfUsersToolStripMenuItem.Text = "Export list of users";
+            // 
+            // currentProjectUsersExportMenuItem
+            // 
+            this.currentProjectUsersExportMenuItem.Name = "currentProjectUsersExportMenuItem";
+            this.currentProjectUsersExportMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.currentProjectUsersExportMenuItem.Text = "Current projects";
+            this.currentProjectUsersExportMenuItem.Click += new System.EventHandler(this.currentProjectUsersExportMenuItem_Click);
+            // 
+            // allProjectUsersExportMenuItem
+            // 
+            this.allProjectUsersExportMenuItem.Name = "allProjectUsersExportMenuItem";
+            this.allProjectUsersExportMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.allProjectUsersExportMenuItem.Text = "All projects";
+            this.allProjectUsersExportMenuItem.Click += new System.EventHandler(this.allProjectUsersExportMenuItem_Click);
             // 
             // exportListOfInstancesForAllProjectsToolStripMenuItem
             // 
@@ -771,14 +798,14 @@
             // allProjectsTSMExportAllInstances
             // 
             this.allProjectsTSMExportAllInstances.Name = "allProjectsTSMExportAllInstances";
-            this.allProjectsTSMExportAllInstances.Size = new System.Drawing.Size(154, 22);
+            this.allProjectsTSMExportAllInstances.Size = new System.Drawing.Size(180, 22);
             this.allProjectsTSMExportAllInstances.Text = "All projects";
             this.allProjectsTSMExportAllInstances.Click += new System.EventHandler(this.allProjectsTSMExportAllInstances_Click);
             // 
             // currentProjectTSMExportAllInstances
             // 
             this.currentProjectTSMExportAllInstances.Name = "currentProjectTSMExportAllInstances";
-            this.currentProjectTSMExportAllInstances.Size = new System.Drawing.Size(154, 22);
+            this.currentProjectTSMExportAllInstances.Size = new System.Drawing.Size(180, 22);
             this.currentProjectTSMExportAllInstances.Text = "Current project";
             this.currentProjectTSMExportAllInstances.Click += new System.EventHandler(this.currentProjectTSMExportAllInstances_Click);
             // 
@@ -816,21 +843,21 @@
             // allInstancesExportChangesTSM
             // 
             this.allInstancesExportChangesTSM.Name = "allInstancesExportChangesTSM";
-            this.allInstancesExportChangesTSM.Size = new System.Drawing.Size(180, 22);
+            this.allInstancesExportChangesTSM.Size = new System.Drawing.Size(166, 22);
             this.allInstancesExportChangesTSM.Text = "All instances";
             this.allInstancesExportChangesTSM.Click += new System.EventHandler(this.allInstancesExportChangesTSM_Click);
             // 
             // cloudInstancesExportChangesTSM
             // 
             this.cloudInstancesExportChangesTSM.Name = "cloudInstancesExportChangesTSM";
-            this.cloudInstancesExportChangesTSM.Size = new System.Drawing.Size(180, 22);
+            this.cloudInstancesExportChangesTSM.Size = new System.Drawing.Size(166, 22);
             this.cloudInstancesExportChangesTSM.Text = "Cloud hosted";
             this.cloudInstancesExportChangesTSM.Click += new System.EventHandler(this.cloudInstancesExportChangesTSM_Click);
             // 
             // saasInstancesExportChangesTSM
             // 
             this.saasInstancesExportChangesTSM.Name = "saasInstancesExportChangesTSM";
-            this.saasInstancesExportChangesTSM.Size = new System.Drawing.Size(180, 22);
+            this.saasInstancesExportChangesTSM.Size = new System.Drawing.Size(166, 22);
             this.saasInstancesExportChangesTSM.Text = "Microsoft Hosted";
             this.saasInstancesExportChangesTSM.Click += new System.EventHandler(this.saasInstancesExportChangesTSM_Click);
             // 
@@ -1651,6 +1678,9 @@
         private System.Windows.Forms.ToolStripMenuItem allInstancesExportChangesTSM;
         private System.Windows.Forms.ToolStripMenuItem cloudInstancesExportChangesTSM;
         private System.Windows.Forms.ToolStripMenuItem saasInstancesExportChangesTSM;
+        private System.Windows.Forms.ToolStripMenuItem exportListOfUsersToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem currentProjectUsersExportMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem allProjectUsersExportMenuItem;
     }
 }
 

--- a/2LCS/Forms/MainForm.Designer.cs
+++ b/2LCS/Forms/MainForm.Designer.cs
@@ -766,7 +766,7 @@
             // 
             this.currentProjectUsersExportMenuItem.Name = "currentProjectUsersExportMenuItem";
             this.currentProjectUsersExportMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.currentProjectUsersExportMenuItem.Text = "Current projects";
+            this.currentProjectUsersExportMenuItem.Text = "Current project";
             this.currentProjectUsersExportMenuItem.Click += new System.EventHandler(this.currentProjectUsersExportMenuItem_Click);
             // 
             // allProjectUsersExportMenuItem

--- a/2LCS/Forms/MainForm.cs
+++ b/2LCS/Forms/MainForm.cs
@@ -917,6 +917,9 @@ namespace LCS.Forms
             RefreshMenuItem_Click(null, null);
             var projectUsers = _httpClientHelper.GetAllProjectUsers();
 
+            bool includeRdpEntryPassword = Properties.Settings.Default.RDPCredentialsEnabled;
+            bool exportCHECredentials = Properties.Settings.Default.LocalCredentialsEnabled;
+
             notifyIcon.BalloonTipText = $"Exporting data for {_selectedProject.Name} project. Please wait...";
             notifyIcon.BalloonTipTitle = "Exporting LCS project data";
 
@@ -1087,33 +1090,36 @@ namespace LCS.Forms
                         }
 
                         instanceHeader.InsertTableAfterSelf(instanceDetailsTable);
-
-                        var rdpList = _httpClientHelper.GetRdpConnectionDetails(saasInstance);
-                        if (rdpList.Count > 0)
+                        if (includeRdpEntryPassword)
                         {
-                            var vms = document.InsertParagraph("RDP connections: " + saasInstance.DisplayName.ToUpper()).FontSize(14d);
-                            vms.SpacingBefore(20d);
-                            vms.SpacingAfter(10d);
-                            foreach (var rdpEntry in rdpList)
+                            var rdpList = _httpClientHelper.GetRdpConnectionDetails(saasInstance);
+                            if (rdpList.Count > 0)
                             {
-                                //RDP details table
-                                var columnWidths = new float[] { 300f, 400f };
-                                var rdpTable = document.AddTable(4, columnWidths.Length);
-                                rdpTable.SetWidths(columnWidths);
-                                rdpTable.Design = TableDesign.LightListAccent1;
-                                rdpTable.Alignment = Alignment.left;
-                                rdpTable.AutoFit = AutoFit.Contents;
-                                rdpTable.Rows[0].Cells[0].Paragraphs[0].Append("Machine name");
-                                rdpTable.Rows[0].Cells[1].Paragraphs[0].Append(rdpEntry.Machine);
-                                rdpTable.Rows[1].Cells[0].Paragraphs[0].Append("RDP address");
-                                rdpTable.Rows[1].Cells[1].Paragraphs[0].Append(rdpEntry.Address + ":" + rdpEntry.Port);
-                                rdpTable.Rows[2].Cells[0].Paragraphs[0].Append("User name");
-                                rdpTable.Rows[2].Cells[1].Paragraphs[0].Append(rdpEntry.Domain + "\\" + rdpEntry.Username);
-                                rdpTable.Rows[3].Cells[0].Paragraphs[0].Append("Password");
-                                rdpTable.Rows[3].Cells[1].Paragraphs[0].Append(rdpEntry.Password);
+                                var vms = document.InsertParagraph("RDP connections: " + saasInstance.DisplayName.ToUpper()).FontSize(14d);
+                                vms.SpacingBefore(20d);
+                                vms.SpacingAfter(10d);
+                                foreach (var rdpEntry in rdpList)
+                                {
+                                    //RDP details table
+                                    var columnWidths = new float[] { 300f, 400f };
+                                    var rdpTable = document.AddTable(4, columnWidths.Length);
+                                    rdpTable.SetWidths(columnWidths);
+                                    rdpTable.Design = TableDesign.LightListAccent1;
+                                    rdpTable.Alignment = Alignment.left;
+                                    rdpTable.AutoFit = AutoFit.Contents;
+                                    rdpTable.Rows[0].Cells[0].Paragraphs[0].Append("Machine name");
+                                    rdpTable.Rows[0].Cells[1].Paragraphs[0].Append(rdpEntry.Machine);
+                                    rdpTable.Rows[1].Cells[0].Paragraphs[0].Append("RDP address");
+                                    rdpTable.Rows[1].Cells[1].Paragraphs[0].Append(rdpEntry.Address + ":" + rdpEntry.Port);
+                                    rdpTable.Rows[2].Cells[0].Paragraphs[0].Append("User name");
+                                    rdpTable.Rows[2].Cells[1].Paragraphs[0].Append(rdpEntry.Domain + "\\" + rdpEntry.Username);
+                                    rdpTable.Rows[3].Cells[0].Paragraphs[0].Append("Password");
+                                    rdpTable.Rows[3].Cells[1].Paragraphs[0].Append(rdpEntry.Password);
+                        
                                 document.InsertTable(rdpTable);
                                 document.InsertParagraph();
                             }
+                        }
                         }
                         foreach (var vm in saasInstance.Instances)
                         {
@@ -1206,69 +1212,77 @@ namespace LCS.Forms
                         }
 
                         instanceHeader.InsertTableAfterSelf(instanceDetailsTable);
-                        var rdpList = _httpClientHelper.GetRdpConnectionDetails(instance);
-                        if (rdpList.Count > 0)
+                        if (includeRdpEntryPassword)
                         {
-                            var vms = document.InsertParagraph("RDP connections: " + instance.DisplayName.ToUpper()).FontSize(14d);
-                            vms.SpacingBefore(20d);
-                            vms.SpacingAfter(10d);
-                            foreach (var rdpEntry in rdpList)
+                            var rdpList = _httpClientHelper.GetRdpConnectionDetails(instance);
+                            if (rdpList.Count > 0)
                             {
-                                //RDP details table
-                                var columnWidths = new float[] { 300f, 400f };
-                                var rdpTable = document.AddTable(3, columnWidths.Length);
-                                rdpTable.SetWidths(columnWidths);
-                                rdpTable.Design = TableDesign.LightListAccent1;
-                                rdpTable.Alignment = Alignment.left;
-                                rdpTable.AutoFit = AutoFit.Contents;
-                                rdpTable.Rows[0].Cells[0].Paragraphs[0].Append("RDP address");
-                                rdpTable.Rows[0].Cells[1].Paragraphs[0].Append(rdpEntry.Address + ":" + rdpEntry.Port);
-                                rdpTable.Rows[1].Cells[0].Paragraphs[0].Append("User name");
-                                rdpTable.Rows[1].Cells[1].Paragraphs[0].Append(rdpEntry.Domain + "\\" + rdpEntry.Username);
-                                rdpTable.Rows[2].Cells[0].Paragraphs[0].Append("Password");
-                                rdpTable.Rows[2].Cells[1].Paragraphs[0].Append(rdpEntry.Password);
-                                document.InsertTable(rdpTable);
-                                document.InsertParagraph();
+                                var vms = document.InsertParagraph("RDP connections: " + instance.DisplayName.ToUpper()).FontSize(14d);
+                                vms.SpacingBefore(20d);
+                                vms.SpacingAfter(10d);
+                                foreach (var rdpEntry in rdpList)
+                                {
+                                    //RDP details table
+                                    var columnWidths = new float[] { 300f, 400f };
+                                    var rdpTable = document.AddTable(3, columnWidths.Length);
+                                    rdpTable.SetWidths(columnWidths);
+                                    rdpTable.Design = TableDesign.LightListAccent1;
+                                    rdpTable.Alignment = Alignment.left;
+                                    rdpTable.AutoFit = AutoFit.Contents;
+                                    rdpTable.Rows[0].Cells[0].Paragraphs[0].Append("RDP address");
+                                    rdpTable.Rows[0].Cells[1].Paragraphs[0].Append(rdpEntry.Address + ":" + rdpEntry.Port);
+                                    rdpTable.Rows[1].Cells[0].Paragraphs[0].Append("User name");
+                                    rdpTable.Rows[1].Cells[1].Paragraphs[0].Append(rdpEntry.Domain + "\\" + rdpEntry.Username);                             
+                                    rdpTable.Rows[2].Cells[0].Paragraphs[0].Append("Password");                            
+                                    rdpTable.Rows[2].Cells[1].Paragraphs[0].Append(rdpEntry.Password);
+
+                                    document.InsertTable(rdpTable);
+                                    document.InsertParagraph();
+                                }
                             }
                         }
-                        foreach (var vm in instance.Instances)
-                        {
-                            var CredentialsDict = _httpClientHelper.GetCredentials(instance.EnvironmentId, vm.ItemName);
-                            if (CredentialsDict.Count > 0)
-                            {
-                                var credentialsParagraph = document.InsertParagraph("Credentials").FontSize(14d);
-                                credentialsParagraph.SpacingBefore(20d);
-                                credentialsParagraph.SpacingAfter(10d);
-                                // CHE credentials table
-                                var columnWidths = new float[] { 150f, 150f };
-                                var credentialsTable = document.AddTable(1, columnWidths.Length);
-                                credentialsTable.SetWidths(columnWidths);
-                                credentialsTable.Design = TableDesign.LightListAccent3;
-                                credentialsTable.Alignment = Alignment.left;
-                                credentialsTable.AutoFit = AutoFit.Contents;
-                                credentialsTable.Rows[0].Cells[0].Paragraphs[0].Append("User name");
-                                credentialsTable.Rows[0].Cells[1].Paragraphs[0].Append("Password");
 
-                                foreach (var credential in CredentialsDict)
+                        if (exportCHECredentials)
+                        {
+                            foreach (var vm in instance.Instances)
+                            {
+                                var CredentialsDict = _httpClientHelper.GetCredentials(instance.EnvironmentId, vm.ItemName);
+                                if (CredentialsDict.Count > 0)
                                 {
-                                    var r = credentialsTable.InsertRow();
-                                    r.Cells[0].Paragraphs[0].Append(credential.Key
-                                        .Replace("Dev-Local admin-", "")
-                                        .Replace("Dev-Local user-", "")
-                                        .Replace("Dev-Sql server login-", "")
-                                        .Replace("Build-Local user-", "")
-                                        .Replace("Build-Sql server login-", "")
-                                        .Replace("AOS-Local admin-", "")
-                                        .Replace("BI-Local admin-", "")
-                                        .Replace("AD-AosServiceUser-", "")
-                                        .Replace("AD-SqlServiceUser-", "")
-                                        .Replace("AD-DynamicsInstallUser-", "")
-                                        .Replace("AD-SPServiceUser-", "")
-                                        .Replace("AD-BCProxyUser-", "")
-                                        .Replace("AD-Local admin-", ""));
-                                    r.Cells[1].Paragraphs[0].Append(credential.Value);
+                                    var credentialsParagraph = document.InsertParagraph("Credentials").FontSize(14d);
+                                    credentialsParagraph.SpacingBefore(20d);
+                                    credentialsParagraph.SpacingAfter(10d);
+                                    // CHE credentials table
+                                    var columnWidths = new float[] { 150f, 150f };
+                                    var credentialsTable = document.AddTable(1, columnWidths.Length);
+                                    credentialsTable.SetWidths(columnWidths);
+                                    credentialsTable.Design = TableDesign.LightListAccent3;
+                                    credentialsTable.Alignment = Alignment.left;
+                                    credentialsTable.AutoFit = AutoFit.Contents;
+                                    credentialsTable.Rows[0].Cells[0].Paragraphs[0].Append("User name");
+                                    credentialsTable.Rows[0].Cells[1].Paragraphs[0].Append("Password");
+
+                                    foreach (var credential in CredentialsDict)
+                                    {
+                                        var r = credentialsTable.InsertRow();
+                                        r.Cells[0].Paragraphs[0].Append(credential.Key
+                                            .Replace("Dev-Local admin-", "")
+                                            .Replace("Dev-Local user-", "")
+                                            .Replace("Dev-Sql server login-", "")
+                                            .Replace("Build-Local user-", "")
+                                            .Replace("Build-Sql server login-", "")
+                                            .Replace("AOS-Local admin-", "")
+                                            .Replace("BI-Local admin-", "")
+                                            .Replace("AD-AosServiceUser-", "")
+                                            .Replace("AD-SqlServiceUser-", "")
+                                            .Replace("AD-DynamicsInstallUser-", "")
+                                            .Replace("AD-SPServiceUser-", "")
+                                            .Replace("AD-BCProxyUser-", "")
+                                            .Replace("AD-Local admin-", ""));
+                                        r.Cells[1].Paragraphs[0].Append(credential.Value);
+                                    }
+                                    credentialsParagraph.InsertTableAfterSelf(credentialsTable).InsertPageBreakAfterSelf();
                                 }
-                                credentialsParagraph.InsertTableAfterSelf(credentialsTable).InsertPageBreakAfterSelf();
                             }
                         }
                     }

--- a/2LCS/Forms/Parameters.Designer.cs
+++ b/2LCS/Forms/Parameters.Designer.cs
@@ -42,10 +42,14 @@
             this.groupCHE = new System.Windows.Forms.GroupBox();
             this.uriSchemeEnabled = new System.Windows.Forms.CheckBox();
             this.alwaysLogAsAdmin = new System.Windows.Forms.CheckBox();
+            this.groupBoxCredentials = new System.Windows.Forms.GroupBox();
+            this.LocalCredentialsCheckbox = new System.Windows.Forms.CheckBox();
+            this.RDPCredentialsCheckbox = new System.Windows.Forms.CheckBox();
             this.groupBoxExportConfig.SuspendLayout();
             this.groupBoxUIConfig.SuspendLayout();
             this.groupBoxCaching.SuspendLayout();
             this.groupCHE.SuspendLayout();
+            this.groupBoxCredentials.SuspendLayout();
             this.SuspendLayout();
             // 
             // AutoRefreshCheckBox
@@ -62,7 +66,7 @@
             // closeButton
             // 
             this.closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.closeButton.Location = new System.Drawing.Point(234, 290);
+            this.closeButton.Location = new System.Drawing.Point(234, 362);
             this.closeButton.Margin = new System.Windows.Forms.Padding(2);
             this.closeButton.Name = "closeButton";
             this.closeButton.Size = new System.Drawing.Size(122, 21);
@@ -95,7 +99,7 @@
             // 
             // textBoxProjectExcl
             // 
-            this.textBoxProjectExcl.Location = new System.Drawing.Point(188, 32);
+            this.textBoxProjectExcl.Location = new System.Drawing.Point(188, 25);
             this.textBoxProjectExcl.Margin = new System.Windows.Forms.Padding(2);
             this.textBoxProjectExcl.Name = "textBoxProjectExcl";
             this.textBoxProjectExcl.Size = new System.Drawing.Size(158, 20);
@@ -117,7 +121,7 @@
             // minimizeToNotificationArea
             // 
             this.minimizeToNotificationArea.AutoSize = true;
-            this.minimizeToNotificationArea.Location = new System.Drawing.Point(5, 37);
+            this.minimizeToNotificationArea.Location = new System.Drawing.Point(6, 37);
             this.minimizeToNotificationArea.Name = "minimizeToNotificationArea";
             this.minimizeToNotificationArea.Size = new System.Drawing.Size(254, 17);
             this.minimizeToNotificationArea.TabIndex = 2;
@@ -151,7 +155,7 @@
             // StoreCacheCheckBox
             // 
             this.StoreCacheCheckBox.AutoSize = true;
-            this.StoreCacheCheckBox.Location = new System.Drawing.Point(4, 37);
+            this.StoreCacheCheckBox.Location = new System.Drawing.Point(6, 37);
             this.StoreCacheCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.StoreCacheCheckBox.Name = "StoreCacheCheckBox";
             this.StoreCacheCheckBox.Size = new System.Drawing.Size(212, 17);
@@ -162,7 +166,7 @@
             // CachingEnabledCheckbox
             // 
             this.CachingEnabledCheckbox.AutoSize = true;
-            this.CachingEnabledCheckbox.Location = new System.Drawing.Point(4, 16);
+            this.CachingEnabledCheckbox.Location = new System.Drawing.Point(6, 16);
             this.CachingEnabledCheckbox.Margin = new System.Windows.Forms.Padding(2);
             this.CachingEnabledCheckbox.Name = "CachingEnabledCheckbox";
             this.CachingEnabledCheckbox.Size = new System.Drawing.Size(110, 17);
@@ -175,7 +179,7 @@
             // 
             this.groupCHE.Controls.Add(this.uriSchemeEnabled);
             this.groupCHE.Controls.Add(this.alwaysLogAsAdmin);
-            this.groupCHE.Location = new System.Drawing.Point(10, 210);
+            this.groupCHE.Location = new System.Drawing.Point(8, 281);
             this.groupCHE.Name = "groupCHE";
             this.groupCHE.Size = new System.Drawing.Size(346, 70);
             this.groupCHE.TabIndex = 9;
@@ -184,7 +188,7 @@
             // 
             // uriSchemeEnabled
             // 
-            this.uriSchemeEnabled.Location = new System.Drawing.Point(5, 42);
+            this.uriSchemeEnabled.Location = new System.Drawing.Point(6, 42);
             this.uriSchemeEnabled.Margin = new System.Windows.Forms.Padding(2);
             this.uriSchemeEnabled.Name = "uriSchemeEnabled";
             this.uriSchemeEnabled.Size = new System.Drawing.Size(169, 20);
@@ -194,18 +198,50 @@
             // 
             // alwaysLogAsAdmin
             // 
-            this.alwaysLogAsAdmin.Location = new System.Drawing.Point(5, 18);
+            this.alwaysLogAsAdmin.Location = new System.Drawing.Point(6, 18);
             this.alwaysLogAsAdmin.Margin = new System.Windows.Forms.Padding(2);
             this.alwaysLogAsAdmin.Name = "alwaysLogAsAdmin";
             this.alwaysLogAsAdmin.Size = new System.Drawing.Size(153, 20);
             this.alwaysLogAsAdmin.TabIndex = 0;
             this.alwaysLogAsAdmin.Text = "Always log as admin user";
             // 
+            // groupBoxCredentials
+            // 
+            this.groupBoxCredentials.Controls.Add(this.LocalCredentialsCheckbox);
+            this.groupBoxCredentials.Controls.Add(this.RDPCredentialsCheckbox);
+            this.groupBoxCredentials.Location = new System.Drawing.Point(8, 208);
+            this.groupBoxCredentials.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBoxCredentials.Name = "groupBoxCredentials";
+            this.groupBoxCredentials.Padding = new System.Windows.Forms.Padding(2);
+            this.groupBoxCredentials.Size = new System.Drawing.Size(347, 68);
+            this.groupBoxCredentials.TabIndex = 6;
+            this.groupBoxCredentials.TabStop = false;
+            this.groupBoxCredentials.Text = "Export project data";
+            // 
+            // LocalCredentialsCheckbox
+            // 
+            this.LocalCredentialsCheckbox.Location = new System.Drawing.Point(6, 41);
+            this.LocalCredentialsCheckbox.Margin = new System.Windows.Forms.Padding(2);
+            this.LocalCredentialsCheckbox.Name = "LocalCredentialsCheckbox";
+            this.LocalCredentialsCheckbox.Size = new System.Drawing.Size(153, 20);
+            this.LocalCredentialsCheckbox.TabIndex = 2;
+            this.LocalCredentialsCheckbox.Text = "Include local credentials";
+            // 
+            // RDPCredentialsCheckbox
+            // 
+            this.RDPCredentialsCheckbox.Location = new System.Drawing.Point(6, 17);
+            this.RDPCredentialsCheckbox.Margin = new System.Windows.Forms.Padding(2);
+            this.RDPCredentialsCheckbox.Name = "RDPCredentialsCheckbox";
+            this.RDPCredentialsCheckbox.Size = new System.Drawing.Size(153, 20);
+            this.RDPCredentialsCheckbox.TabIndex = 1;
+            this.RDPCredentialsCheckbox.Text = "Include RDP credentials";
+            // 
             // Parameters
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(389, 321);
+            this.ClientSize = new System.Drawing.Size(389, 393);
+            this.Controls.Add(this.groupBoxCredentials);
             this.Controls.Add(this.groupBoxUIConfig);
             this.Controls.Add(this.groupBoxCaching);
             this.Controls.Add(this.groupBoxExportConfig);
@@ -228,6 +264,7 @@
             this.groupBoxCaching.ResumeLayout(false);
             this.groupBoxCaching.PerformLayout();
             this.groupCHE.ResumeLayout(false);
+            this.groupBoxCredentials.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -253,5 +290,8 @@
         private System.Windows.Forms.GroupBox groupCHE;
         private System.Windows.Forms.CheckBox alwaysLogAsAdmin;
         private System.Windows.Forms.CheckBox uriSchemeEnabled;
+        private System.Windows.Forms.GroupBox groupBoxCredentials;
+        private System.Windows.Forms.CheckBox RDPCredentialsCheckbox;
+        private System.Windows.Forms.CheckBox LocalCredentialsCheckbox;
     }
 }

--- a/2LCS/Forms/Parameters.cs
+++ b/2LCS/Forms/Parameters.cs
@@ -37,6 +37,8 @@ namespace LCS.Forms
             AutoRefreshCheckBox.Checked = Properties.Settings.Default.autorefresh;
             minimizeToNotificationArea.Checked = Properties.Settings.Default.minimizeToNotificationArea;
             textBoxProjectExcl.Text = Properties.Settings.Default.projOrgExcl;
+            RDPCredentialsCheckbox.Checked = Properties.Settings.Default.RDPCredentialsEnabled;
+            LocalCredentialsCheckbox.Checked = Properties.Settings.Default.LocalCredentialsEnabled;
             CachingEnabledCheckbox.Checked = Properties.Settings.Default.cachingEnabled;
             StoreCacheCheckBox.Checked = Properties.Settings.Default.keepCache;
             alwaysLogAsAdmin.Checked = Properties.Settings.Default.alwaysLogAsAdmin;
@@ -49,6 +51,8 @@ namespace LCS.Forms
             Properties.Settings.Default.autorefresh = AutoRefreshCheckBox.Checked;
             Properties.Settings.Default.minimizeToNotificationArea = minimizeToNotificationArea.Checked;
             Properties.Settings.Default.projOrgExcl = textBoxProjectExcl.Text;
+            Properties.Settings.Default.RDPCredentialsEnabled = RDPCredentialsCheckbox.Checked;
+            Properties.Settings.Default.LocalCredentialsEnabled = LocalCredentialsCheckbox.Checked;
             Properties.Settings.Default.cachingEnabled = CachingEnabledCheckbox.Checked;
             Properties.Settings.Default.keepCache = StoreCacheCheckBox.Checked;
             Properties.Settings.Default.alwaysLogAsAdmin = alwaysLogAsAdmin.Checked;

--- a/2LCS/JsonObjects.cs
+++ b/2LCS/JsonObjects.cs
@@ -219,6 +219,23 @@ namespace LCS.JsonObjects
         public string TopologyVersion { get; set; }
     }
 
+    public class ExportedUser
+    {
+        public string Organization { get; set; }
+        public string ProjectId { get; set; }
+        public string ProjectName { get; set; }
+        public string UserName { get; set; }
+        public string Email { get; set; }
+        public string OrganizationName { get; set; }
+        public string UserRoleDisplayName { get; set; }
+        public string FunctionalRoleDisplayName { get; set; }
+        public string AllowContactByMicrosoft { get; set; }
+        public string InvitedByName { get; set; }
+        public string InvitedByOrganisation { get; set; }
+        public string CreatedDate { get; set; }
+        public string InvitationStatusDisplayText { get; set; }
+    }
+
     public class Hotfix
     {
         public object Area { get; set; }

--- a/2LCS/Properties/Settings.Designer.cs
+++ b/2LCS/Properties/Settings.Designer.cs
@@ -106,7 +106,37 @@ namespace LCS.Properties {
                 this["projOrgExcl"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RDPCredentialsEnabled
+        {
+            get
+            {
+                return ((bool)(this["RDPCredentialsEnabled"]));
+            }
+            set
+            {
+                this["RDPCredentialsEnabled"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LocalCredentialsEnabled
+        {
+            get
+            {
+                return ((bool)(this["LocalCredentialsEnabled"]));
+            }
+            set
+            {
+                this["LocalCredentialsEnabled"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]


### PR DESCRIPTION
Maintaining user access to LCS across many projects is cumbersome. Since LCS is not tied to Azure AD users it is possible for Project Admins to add external users without first tying them to Azure AD for the tenant which the project is linked. This feature produces a list of LCS users for the selected project or all projects such that this can be more easily audited.