### PR TITLE
improve release action

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -54,4 +54,4 @@ jobs:
         draft: false
         prerelease: true
         generate_release_notes: true
-        files: 2LCS_${{ inputs.version }}.zip
+        files: 2LCS_${{ inputs.release_name }}.zip

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -16,13 +16,6 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
-      checks: write
-      actions: read
-      issues: read
-      packages: write
-      pull-requests: read
-      repository-projects: read
-      statuses: read
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -9,14 +9,13 @@ name: Build and add to new release
 # trigger manually
 on: 
   workflow_dispatch:
-
-  inputs:
-    release_name:
-      description: 'Name of the release (e.g. v.0.47.0)'
-      required: true
-    version:
-      description: 'Version of the release (e.g. 0.47.0)'
-      required: true
+    inputs:
+      release_name:
+        description: 'Name of the release (e.g. v.0.47.0)'
+        required: true
+      version:
+        description: 'Version of the release (e.g. 0.47.0)'
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -1,15 +1,22 @@
 # Action to build and release a new version of the project
-# The workflow is triggered when a new release is created. 
-# The workflow builds the project and uploads the 2LCS.zip file to the release.
-# The workflow uses the GitHub Actions upload-release-asset action to upload the 2LCS.zip file to the release. 
+# The workflow is triggered manually.
+# The workflow builds the project, creates a new release and uploads the 2LCS.zip file to it.
+# The workflow uses the GitHub Actions softprops/action-gh-release action to create the release with the 2LCS.zip file. 
 # The action takes a number of parameters, which are documented in the action's repository. 
 
-name: Build and add to release
+name: Build and add to new release
 
-# trigger on a release
+# trigger manually
 on: 
-  release:
-    types: [published]
+  workflow_dispatch:
+
+  inputs:
+    release_name:
+      description: 'Name of the release (e.g. v.0.47.0)'
+      required: true
+    version:
+      description: 'Version of the release (e.g. 0.47.0)'
+      required: true
 
 jobs:
   build:
@@ -29,23 +36,23 @@ jobs:
       run: nuget restore 2LCS/2LCS.csproj
 
     - name: Build
-      run: msbuild 2LCS/2LCS.csproj /p:Configuration=Release /p:OutputPath=2LCS/bin/Release
+      run: msbuild 2LCS/2LCS.csproj /p:Configuration=Release /p:OutputPath=2LCS/bin/Release /p:Version=${{ inputs.version }}
 
-    - name: Upload 2LCS_${{ github.event.release.tag_name }} .zip
+    - name: Upload ${{ inputs.release_name }}.zip
       uses: actions/upload-artifact@v4
       with:
-        name: 2LCS_${{ github.event.release.tag_name }}
+        name: 2LCS_${{ inputs.release_name }}
         path: 2LCS/bin/Release
 
     - name: Create zip file from content of release folder
-      run: Compress-Archive -Path 2LCS\bin\Release\* -DestinationPath 2LCS_${{ github.event.release.tag_name }}.zip
+      run: Compress-Archive -Path 2LCS\bin\Release\* -DestinationPath 2LCS_${{ inputs.release_name }}.zip
 
-    - name: Upload 2LCS .zip to release ${{ github.event.release.name }}
-      uses: shogo82148/actions-upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create release
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=2LCS_${{ github.event.release.tag_name }}.zip
-        asset_path: 2LCS_${{ github.event.release.tag_name }}.zip
-        asset_name: 2LCS_${{ github.event.release.tag_name }}.zip
-        asset_content_type: application/zip
+        name: ${{ inputs.release_name }}
+        tag_name: ${{ inputs.release_name }}
+        draft: false
+        prerelease: true
+        generate_release_notes: true
+        files: 2LCS_${{ inputs.version }}.zip

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -35,7 +35,7 @@ jobs:
       run: nuget restore 2LCS/2LCS.csproj
 
     - name: Build
-      run: msbuild 2LCS/2LCS.csproj /p:Configuration=Release /p:OutputPath=2LCS/bin/Release /p:Version=${{ inputs.version }}
+      run: msbuild 2LCS/2LCS.csproj /p:Configuration=Release /p:OutputPath=bin/Release /p:Version=${{ inputs.version }}
 
     - name: Upload ${{ inputs.release_name }}.zip
       uses: actions/upload-artifact@v4

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -29,7 +29,7 @@ jobs:
       run: nuget restore 2LCS/2LCS.csproj
 
     - name: Build
-      run: msbuild 2LCS/2LCS.csproj /p:Configuration=Release
+      run: msbuild 2LCS/2LCS.csproj /p:Configuration=Release /p:OutputPath=2LCS/bin/Release
 
     - name: Upload 2LCS_${{ github.event.release.tag_name }} .zip
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- adds the version to the executable again
- removes unnecessary subfolder in .zip file
- changes github action to manual trigger with inputs specifying the release name and version; this will automatically create a new release with auto generated release notes; it is created as a prerelease, so release notes can be edited before manually setting it to a full release
- removes unnecessary permissions