### PR TITLE
Update action gh release version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,6 @@ jobs:
       run: msbuild 2LCS/2LCS.csproj /p:VersionSuffix=pr /p:Configuration=Release /p:Version=0.0.0.${{ github.event.pull_request.number }} /p:InformationalVersion=0.0.0.${{ github.event.pull_request.number }}-pr
     - name: Upload 2LCS.zip
       uses: actions/upload-artifact@v3
-      # uses: softprops/action-gh-release@v1
       with:
         name: 2LCS
         path: 2LCS/bin/Release    

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -47,7 +47,7 @@ jobs:
       run: Compress-Archive -Path 2LCS\bin\Release\* -DestinationPath 2LCS_${{ inputs.release_name }}.zip
 
     - name: Create release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         name: ${{ inputs.release_name }}
         tag_name: ${{ inputs.release_name }}


### PR DESCRIPTION
Updates the softprops/action-gh-release to version 2 to address the Node.js 16 warning.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: softprops/action-gh-release@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/