### PR TITLE
Update GitHub Actions and NuGet setup

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,17 +10,22 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
+
     - name: Setup NuGet
-      uses: nuget/setup-nuget@v1
+      uses: nuget/setup-nuget@v2
+
     - name: Restore NuGet packages
       run: nuget restore 2LCS/2LCS.csproj
+
     - name: Build
       run: msbuild 2LCS/2LCS.csproj /p:VersionSuffix=pr /p:Configuration=Release /p:Version=0.0.0.${{ github.event.pull_request.number }} /p:InformationalVersion=0.0.0.${{ github.event.pull_request.number }}-pr
+
     - name: Upload 2LCS.zip
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: 2LCS
         path: 2LCS/bin/Release    


### PR DESCRIPTION
Updates the actions to transition from Node.js 16 to 20 to avoid warning message. See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/