### PR TITLE
Optionally populate external IP address when creating firewall exceptions

### DIFF
--- a/2LCS/2LCS.csproj
+++ b/2LCS/2LCS.csproj
@@ -47,8 +47,17 @@
     <Compile Update="ExtendedWebBrowser.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
     <None Update="LICENSE">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/2LCS/App.config
+++ b/2LCS/App.config
@@ -67,6 +67,9 @@
             <setting name="lcsFixURL" serializeAs="String">
                 <value>https://fix.lcs.dynamics.com</value>
             </setting>
+            <setting name="populateOwnIPForNSG" serializeAs="String">
+                <value>False</value>
+            </setting>
         </LCS.Properties.Settings>
     </userSettings>
   <runtime>

--- a/2LCS/Forms/AddNSG.cs
+++ b/2LCS/Forms/AddNSG.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Windows.Forms;
 
 namespace LCS.Forms
@@ -11,6 +12,8 @@ namespace LCS.Forms
         public AddNsg()
         {
             InitializeComponent();
+
+            PopulateWithOwnIP();
         }
 
         public bool Cancelled { get; private set; }
@@ -39,6 +42,27 @@ namespace LCS.Forms
         {
             Cancelled = true;
             Close();
+        }
+
+        private void PopulateWithOwnIP()
+        {
+            if (Properties.Settings.Default.populateOwnIPForNSG)
+            {
+                try
+                {
+                    var ownIpAddress = new HttpClient().GetStringAsync("http://icanhazip.com").Result;
+                    ownIpAddress = ownIpAddress.Replace("\\r\\n", "").Replace("\\n", "").Trim();
+
+                    if (!string.IsNullOrEmpty(ownIpAddress))
+                    {
+                        textBox2.Text = ownIpAddress;
+                    }
+                }
+                catch
+                {
+                    MessageBox.Show("Failed to get your IP address. Please enter it manually.");
+                }
+            }
         }
 
         private bool ValidateRule()

--- a/2LCS/Forms/Parameters.Designer.cs
+++ b/2LCS/Forms/Parameters.Designer.cs
@@ -46,20 +46,23 @@
             LocalCredentialsCheckbox = new System.Windows.Forms.CheckBox();
             RDPCredentialsCheckbox = new System.Windows.Forms.CheckBox();
             groupBoxLCSUrls = new System.Windows.Forms.GroupBox();
+            labelLcsDiagUrl = new System.Windows.Forms.Label();
+            labelLcsFixUrl = new System.Windows.Forms.Label();
+            labelLcsUpdateUrl = new System.Windows.Forms.Label();
             labelLcsUrl = new System.Windows.Forms.Label();
             textBoxLcsDiagUrl = new System.Windows.Forms.TextBox();
             textBoxLcsFixUrl = new System.Windows.Forms.TextBox();
             textBoxLcsUpdateUrl = new System.Windows.Forms.TextBox();
             textBoxLcsUrl = new System.Windows.Forms.TextBox();
-            labelLcsUpdateUrl = new System.Windows.Forms.Label();
-            labelLcsFixUrl = new System.Windows.Forms.Label();
-            labelLcsDiagUrl = new System.Windows.Forms.Label();
+            groupBox1 = new System.Windows.Forms.GroupBox();
+            addExternalIpAddress = new System.Windows.Forms.CheckBox();
             groupBoxExportConfig.SuspendLayout();
             groupBoxUIConfig.SuspendLayout();
             groupBoxCaching.SuspendLayout();
             groupCHE.SuspendLayout();
             groupBoxCredentials.SuspendLayout();
             groupBoxLCSUrls.SuspendLayout();
+            groupBox1.SuspendLayout();
             SuspendLayout();
             // 
             // AutoRefreshCheckBox
@@ -75,7 +78,7 @@
             // closeButton
             // 
             closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            closeButton.Location = new System.Drawing.Point(312, 722);
+            closeButton.Location = new System.Drawing.Point(304, 801);
             closeButton.Name = "closeButton";
             closeButton.Size = new System.Drawing.Size(163, 32);
             closeButton.TabIndex = 4;
@@ -179,7 +182,7 @@
             // 
             groupCHE.Controls.Add(uriSchemeEnabled);
             groupCHE.Controls.Add(alwaysLogAsAdmin);
-            groupCHE.Location = new System.Drawing.Point(11, 432);
+            groupCHE.Location = new System.Drawing.Point(12, 433);
             groupCHE.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             groupCHE.Name = "groupCHE";
             groupCHE.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
@@ -242,12 +245,39 @@
             groupBoxLCSUrls.Controls.Add(textBoxLcsFixUrl);
             groupBoxLCSUrls.Controls.Add(textBoxLcsUpdateUrl);
             groupBoxLCSUrls.Controls.Add(textBoxLcsUrl);
-            groupBoxLCSUrls.Location = new System.Drawing.Point(11, 548);
+            groupBoxLCSUrls.Location = new System.Drawing.Point(12, 624);
             groupBoxLCSUrls.Name = "groupBoxLCSUrls";
-            groupBoxLCSUrls.Size = new System.Drawing.Size(461, 165);
+            groupBoxLCSUrls.Size = new System.Drawing.Size(460, 165);
             groupBoxLCSUrls.TabIndex = 10;
             groupBoxLCSUrls.TabStop = false;
             groupBoxLCSUrls.Text = "LCS Urls";
+            // 
+            // labelLcsDiagUrl
+            // 
+            labelLcsDiagUrl.AutoSize = true;
+            labelLcsDiagUrl.Location = new System.Drawing.Point(9, 132);
+            labelLcsDiagUrl.Name = "labelLcsDiagUrl";
+            labelLcsDiagUrl.Size = new System.Drawing.Size(130, 20);
+            labelLcsDiagUrl.TabIndex = 7;
+            labelLcsDiagUrl.Text = "LCS Diagnostic Url";
+            // 
+            // labelLcsFixUrl
+            // 
+            labelLcsFixUrl.AutoSize = true;
+            labelLcsFixUrl.Location = new System.Drawing.Point(9, 99);
+            labelLcsFixUrl.Name = "labelLcsFixUrl";
+            labelLcsFixUrl.Size = new System.Drawing.Size(139, 20);
+            labelLcsFixUrl.TabIndex = 6;
+            labelLcsFixUrl.Text = "LCS Issue Search Url";
+            // 
+            // labelLcsUpdateUrl
+            // 
+            labelLcsUpdateUrl.AutoSize = true;
+            labelLcsUpdateUrl.Location = new System.Drawing.Point(9, 66);
+            labelLcsUpdateUrl.Name = "labelLcsUpdateUrl";
+            labelLcsUpdateUrl.Size = new System.Drawing.Size(108, 20);
+            labelLcsUpdateUrl.TabIndex = 5;
+            labelLcsUpdateUrl.Text = "LCS Update Url";
             // 
             // labelLcsUrl
             // 
@@ -286,38 +316,30 @@
             textBoxLcsUrl.Size = new System.Drawing.Size(203, 27);
             textBoxLcsUrl.TabIndex = 0;
             // 
-            // labelLcsUpdateUrl
+            // groupBox1
             // 
-            labelLcsUpdateUrl.AutoSize = true;
-            labelLcsUpdateUrl.Location = new System.Drawing.Point(9, 66);
-            labelLcsUpdateUrl.Name = "labelLcsUpdateUrl";
-            labelLcsUpdateUrl.Size = new System.Drawing.Size(108, 20);
-            labelLcsUpdateUrl.TabIndex = 5;
-            labelLcsUpdateUrl.Text = "LCS Update Url";
+            groupBox1.Controls.Add(addExternalIpAddress);
+            groupBox1.Location = new System.Drawing.Point(11, 549);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Size = new System.Drawing.Size(461, 69);
+            groupBox1.TabIndex = 11;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Microsoft-hosted environments";
             // 
-            // labelLcsFixUrl
+            // addExternalIpAddress
             // 
-            labelLcsFixUrl.AutoSize = true;
-            labelLcsFixUrl.Location = new System.Drawing.Point(9, 99);
-            labelLcsFixUrl.Name = "labelLcsFixUrl";
-            labelLcsFixUrl.Size = new System.Drawing.Size(139, 20);
-            labelLcsFixUrl.TabIndex = 6;
-            labelLcsFixUrl.Text = "LCS Issue Search Url";
-            // 
-            // labelLcsDiagUrl
-            // 
-            labelLcsDiagUrl.AutoSize = true;
-            labelLcsDiagUrl.Location = new System.Drawing.Point(9, 132);
-            labelLcsDiagUrl.Name = "labelLcsDiagUrl";
-            labelLcsDiagUrl.Size = new System.Drawing.Size(130, 20);
-            labelLcsDiagUrl.TabIndex = 7;
-            labelLcsDiagUrl.Text = "LCS Diagnostic Url";
+            addExternalIpAddress.Location = new System.Drawing.Point(9, 26);
+            addExternalIpAddress.Name = "addExternalIpAddress";
+            addExternalIpAddress.Size = new System.Drawing.Size(363, 31);
+            addExternalIpAddress.TabIndex = 2;
+            addExternalIpAddress.Text = "Add external IP when creating firewall exception";
             // 
             // Parameters
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(519, 770);
+            ClientSize = new System.Drawing.Size(487, 845);
+            Controls.Add(groupBox1);
             Controls.Add(groupBoxLCSUrls);
             Controls.Add(groupBoxCredentials);
             Controls.Add(groupBoxUIConfig);
@@ -344,6 +366,7 @@
             groupBoxCredentials.ResumeLayout(false);
             groupBoxLCSUrls.ResumeLayout(false);
             groupBoxLCSUrls.PerformLayout();
+            groupBox1.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -380,5 +403,7 @@
         private System.Windows.Forms.Label labelLcsDiagUrl;
         private System.Windows.Forms.Label labelLcsFixUrl;
         private System.Windows.Forms.Label labelLcsUpdateUrl;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox addExternalIpAddress;
     }
 }

--- a/2LCS/Forms/Parameters.cs
+++ b/2LCS/Forms/Parameters.cs
@@ -47,6 +47,8 @@ namespace LCS.Forms
             textBoxLcsUpdateUrl.Text = Properties.Settings.Default.lcsUpdateURL;
             textBoxLcsDiagUrl.Text = Properties.Settings.Default.lcsDiagURL;
             textBoxLcsFixUrl.Text = Properties.Settings.Default.lcsFixURL;
+            addExternalIpAddress.Checked = Properties.Settings.Default.populateOwnIPForNSG;
+
             SetStoreCacheEnabledDisabled();
         }
 
@@ -65,6 +67,8 @@ namespace LCS.Forms
             Properties.Settings.Default.lcsUpdateURL = textBoxLcsUpdateUrl.Text;
             Properties.Settings.Default.lcsDiagURL = textBoxLcsDiagUrl.Text;
             Properties.Settings.Default.lcsFixURL = textBoxLcsFixUrl.Text;
+            Properties.Settings.Default.populateOwnIPForNSG = addExternalIpAddress.Checked;
+
             Properties.Settings.Default.Save();
         }
 

--- a/2LCS/Forms/Parameters.resx
+++ b/2LCS/Forms/Parameters.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/2LCS/Properties/Settings.Designer.cs
+++ b/2LCS/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace LCS.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -248,6 +248,18 @@ namespace LCS.Properties {
             }
             set {
                 this["lcsFixURL"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool populateOwnIPForNSG {
+            get {
+                return ((bool)(this["populateOwnIPForNSG"]));
+            }
+            set {
+                this["populateOwnIPForNSG"] = value;
             }
         }
     }

--- a/2LCS/Properties/Settings.settings
+++ b/2LCS/Properties/Settings.settings
@@ -59,5 +59,8 @@
     <Setting Name="lcsFixURL" Type="System.String" Scope="User">
       <Value Profile="(Default)">https://fix.lcs.dynamics.com</Value>
     </Setting>
+    <Setting Name="populateOwnIPForNSG" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Related to #97 

Added a new parameter in settings and form parameter, defaulted to false

![image](https://github.com/user-attachments/assets/459ab69e-2729-4c6c-aa9f-f942ca165d74)

Whenever the user enters the form `AddNSG.cs`, a request is done to `https://icanhazip.com` to retrieve the external IP and populates it into the IP textbox.

I did not include the option to get the IP from another service since icanhazip is a reliable source used by many other projects and other services may have different approaches other than plain text IP.